### PR TITLE
Quote strings that are quoted on the command line.

### DIFF
--- a/when-changed.py
+++ b/when-changed.py
@@ -44,7 +44,13 @@ if __name__ == '__main__':
         print_usage(prog)
         exit(1)
     
-    command = ' '.join(command)
+    def quote(s):
+        if ' ' in s:
+            return "\"" + s + "\""
+        else:
+            return s
+
+    command = ' '.join(map(quote, command))
     
     # Store initial mtimes
     try:


### PR DESCRIPTION
This fixes the quoting issue, since its easy to detect when a string was intended to be quoted.

Let me know if you think there's a better way to go about that, I'm not a pythonista (yet). I'll make changes if you give me a suggestion.
