### PR TITLE
Also listen for move_to events

### DIFF
--- a/whenchanged/whenchanged.py
+++ b/whenchanged/whenchanged.py
@@ -52,17 +52,25 @@ class WhenChanged(pyinotify.ProcessEvent):
 
         return False
 
-    def process_IN_CLOSE_WRITE(self, event):
-        path = event.pathname
+    def on_change(self, path):
         if self.is_interested(path):
             self.run_command(path)
+
+    def process_IN_CLOSE_WRITE(self, event):
+        self.on_change(event.pathname)
+
+    def process_IN_MOVED_TO(self, event):
+        self.on_change(event.pathname)
 
     def run(self):
         wm = pyinotify.WatchManager()
         notifier = pyinotify.Notifier(wm, self)
 
         # Add watches (IN_CREATE is required for auto_add)
-        mask = pyinotify.IN_CLOSE_WRITE | pyinotify.IN_CREATE
+        mask = (pyinotify.IN_CLOSE_WRITE |
+                pyinotify.IN_MOVED_TO |
+                pyinotify.IN_CREATE)
+
         watched = set()
         for p in self.paths:
             if os.path.isdir(p) and not p in watched:


### PR DESCRIPTION
Some editors (namely, IntelliJ IDEA) save by writing to a temporary file and then moving the temporary file to replace the file being edited. Because when-changed wasn't listening for move events, it didn't notice those file replacements.
