### PR TITLE
Added argument parsing with `argparse` if available; extra args to refine notification

### DIFF
--- a/whenchanged/whenchanged.py
+++ b/whenchanged/whenchanged.py
@@ -161,6 +161,7 @@ def main():
         import argparse
     except ImportError:
         args = old_parse_args()
+        d = vars(args)
     else:
         parser = argparse.ArgumentParser()
         parser.add_argument(
@@ -178,8 +179,9 @@ def main():
                 help="Only respond to file modifications.",
                 action='store_true')
         parser.add_argument(
-                "files",
-                help="The files or folders to watch.",
+                "arg",
+                help="FILE [COMMAND] ....  Alternatively, if the `-c` option is"
+                    " used to specify the command: FILE [FILE] ...",
                 action='store',
                 nargs='+')
         parser.add_argument(
@@ -190,9 +192,23 @@ def main():
                 nargs=argparse.REMAINDER,
                 metavar='ARG')
         args = parser.parse_args() 
+        command = args.command
+        files_or_cmd = args.arg
+        if command is not None and len(command) > 0:
+            files = list(files_or_cmd)
+        else:
+            if len(files_or_cmd) == 1:
+                files = list(files_or_cmd)
+            else:
+                files = files_or_cmd[:1]
+                command = files_or_cmd[1:]
+        d = vars(args)
+        del d['arg']
+        d['files'] = files
+        d['command'] = command
 
-    command = args.command
-    files = args.files
+    command = d['command']
+    files = d['files']
     if command is not None and len(command) > 0:
         print_command = ' '.join(command)
     else:
@@ -206,7 +222,7 @@ def main():
     else:
         print("When '%s' changes, run '%s'" % (files[0], print_command))
 
-    wc = WhenChanged(**vars(args))
+    wc = WhenChanged(**d)
     try:
         wc.run()
     except KeyboardInterrupt:


### PR DESCRIPTION
Added argument parsing with `argparse` if available; extra args to refine notification.

When using argparse, there is only one syntax.  If you do not supply a command with '-c', the program prints the file name to STDOUT.
If you do supply a command, it can either be the last option and end with '--' OR if can simply be placed at the end of the command line.  E.g. the following are equivalent:

  $ ./when-changed -r -c ls -l %f -- /path/to/dir1 /path/to/dir2
  $ ./when-changed -r /path/to/dir1 /path/to/dir2 -c ls -l %f

Added options to *only* notify on mods or renames (rather than both).  You can choose to run the command *only* on file renames or *only* on file modifications.  

I am using the `--renames-only` flag in a script I am writing to monitor a file system with a very specific permission structure.  The file system makes use of the setGid bit to force the owning group for new files and folders.  This works great, until a `mv` command or equivalent causes a file to change folders.  I track the renamed files and process them in short batches via a second script that updates permissions.  In this case, I am only really interested in when a file is moved-- not when its contents have been changed.

If `argparse` is not available, fall back to the original command line processing.  (`argparse` is available for Python v2.6 via PyPi, or you can just copy `argparse.py` out of the tarball and put it in the same directory as this script).
