### PR TITLE
Use shell invocation for convenience

### DIFF
--- a/whenchanged/whenchanged.py
+++ b/whenchanged/whenchanged.py
@@ -45,7 +45,7 @@ class WhenChanged(pyinotify.ProcessEvent):
             if item == "%f":
                 item = thefile
             new_command.append(item)
-        subprocess.call(new_command)
+        subprocess.call(new_command, shell=True)
 
     def is_interested(self, path):
         basename = os.path.basename(path)


### PR DESCRIPTION
This solves errors like this:

```
(.venv)shtilman ~/C/shower-jinja:master   when-changed -r slides "bash -c 'python compile.py > ../my-awesome-shower-theme/index.html'"
When 'slides' changes, run 'bash -c 'python compile.py > ../my-awesome-shower-theme/index.html''
Traceback (most recent call last):
  File "/home/corpix/Code/shower-jinja/.venv/bin/when-changed", line 10, in <module>
    execfile(__file__)
  File "/home/corpix/Code/shower-jinja/.venv/src/when-changed/when-changed", line 4, in <module>
    main()
  File "/home/corpix/Code/shower-jinja/.venv/src/when-changed/whenchanged/whenchanged.py", line 149, in main
    wc.run()
  File "/home/corpix/Code/shower-jinja/.venv/src/when-changed/whenchanged/whenchanged.py", line 102, in run
    notifier.loop()
  File "/home/corpix/Code/shower-jinja/.venv/lib/python2.7/site-packages/pyinotify.py", line 1400, in loop
    self.process_events()
  File "/home/corpix/Code/shower-jinja/.venv/lib/python2.7/site-packages/pyinotify.py", line 1295, in process_events
    self._default_proc_fun(revent)
  File "/home/corpix/Code/shower-jinja/.venv/lib/python2.7/site-packages/pyinotify.py", line 937, in __call__
    return _ProcessEvent.__call__(self, event)
  File "/home/corpix/Code/shower-jinja/.venv/lib/python2.7/site-packages/pyinotify.py", line 662, in __call__
    return meth(event)
  File "/home/corpix/Code/shower-jinja/.venv/src/when-changed/whenchanged/whenchanged.py", line 76, in process_IN_CLOSE_WRITE
    self.on_change(event.pathname)
  File "/home/corpix/Code/shower-jinja/.venv/src/when-changed/whenchanged/whenchanged.py", line 73, in on_change
    self.run_command(path)
  File "/home/corpix/Code/shower-jinja/.venv/src/when-changed/whenchanged/whenchanged.py", line 48, in run_command
    subprocess.call(new_command)
  File "/usr/lib64/python2.7/subprocess.py", line 522, in call
    return Popen(*popenargs, **kwargs).wait()
  File "/usr/lib64/python2.7/subprocess.py", line 710, in __init__
    errread, errwrite)
  File "/usr/lib64/python2.7/subprocess.py", line 1327, in _execute_child
    raise child_exception
OSError: [Errno 2] No such file or directory
```
