### PR TITLE
added option to not output any text to terminal (if run in background)

### DIFF
--- a/whenchanged/whenchanged.py
+++ b/whenchanged/whenchanged.py
@@ -1,10 +1,11 @@
 #!/usr/bin/env python
 """%(prog)s - run a command when a file is changed
 
-Usage: %(prog)s [-r] FILE COMMAND...
-       %(prog)s [-r] FILE [FILE ...] -c COMMAND
+Usage: %(prog)s [-q] [-r] FILE COMMAND...
+       %(prog)s [-q] [-r] FILE [FILE ...] -c COMMAND
 
 FILE can be a directory. Watch recursively with -r.
+Omit output to terminal with -q.
 Use %%f to pass the filename to the command.
 
 Copyright (c) 2011, Johannes H. Jensen.
@@ -117,10 +118,15 @@ def main():
     files = []
     command = []
     recursive = False
+    quiet = False
 
-    if args and args[0] == '-r':
+    if '-q' in args:
+        quiet = True
+        args.pop(args.index('-q'))
+
+    if '-r' in args:
         recursive = True
-        args.pop(0)
+        args.pop(args.index('-r'))
 
     if '-c' in args:
         cpos = args.index('-c')
@@ -140,9 +146,11 @@ def main():
     if len(files) > 1:
         l = ["'%s'" % f for f in files]
         s = ', '.join(l[:-1]) + ' or ' + l[-1]
-        print("When %s changes, run '%s'" % (s, print_command))
+        if not quiet:
+            print("When %s changes, run '%s'" % (s, print_command))
     else:
-        print("When '%s' changes, run '%s'" % (files[0], print_command))
+        if not quiet:
+            print("When '%s' changes, run '%s'" % (files[0], print_command))
 
     wc = WhenChanged(files, command, recursive)
     try:


### PR DESCRIPTION
I've added an option `-q` so that no text is printed to the terminal. This might be useful for people who want to run this script in the background.
IMO it should be the other way around: the text for the user should only be printed when requested (a separate -d debug option), but it's not my script, so I've just added a `-q` (quiet) option.
