### PR TITLE
Filter watching files with the file suffix. Fix trigger multitimes in some conditions.

### DIFF
--- a/README
+++ b/README
@@ -35,3 +35,5 @@
 
       when-changed FILE COMMAND...
       when-changed FILE [FILE ...] -c COMMAND
+      when-changed -r DIR -c COMMAND
+      when-changed -r DIR -s py,js,css -c COMMAND

--- a/whenchanged/whenchanged.py
+++ b/whenchanged/whenchanged.py
@@ -89,15 +89,15 @@ class WhenChanged(pyinotify.ProcessEvent):
 
         watched = set()
         for p in self.paths:
-            if os.path.isdir(p) and not p in watched:
+            if os.path.isdir(p) and p not in watched:
                 # Add directory
-                wdd = wm.add_watch(p, mask, rec=self.recursive,
-                                   auto_add=self.recursive)
+                wm.add_watch(p, mask, rec=self.recursive,
+                             auto_add=self.recursive)
             else:
                 # Add parent directory
                 path = os.path.dirname(p)
-                if not path in watched:
-                    wdd = wm.add_watch(path, mask)
+                if path not in watched:
+                    wm.add_watch(path, mask)
 
         notifier.loop()
 

--- a/whenchanged/whenchanged.py
+++ b/whenchanged/whenchanged.py
@@ -16,6 +16,7 @@ from __future__ import print_function
 import sys
 import os
 import re
+from datetime import datetime
 
 # External modules.
 import pyinotify
@@ -26,11 +27,25 @@ except ImportError:
     import subprocess
 
 
+def run_once(fn):
+    '''
+    When event trigger interval less than 0.5s, treat
+    as one trigger
+    '''
+    def wrapper(self, *args, **kwargs):
+        now = datetime.now()
+        delta = now - self.last_run_time
+        if delta.total_seconds() > 0.5:
+            fn(self, *args, **kwargs)
+            self.last_run_time = now
+    return wrapper
+
+
 class WhenChanged(pyinotify.ProcessEvent):
     # Exclude Vim swap files, its file creation test file 4913 and backup files
     exclude = re.compile(r'^\..*\.sw[px]*$|^4913$|.~$')
 
-    def __init__(self, files, command, recursive=False):
+    def __init__(self, files, command, recursive=False, suffixes=None):
         self.files = files
         paths = {}
         for f in files:
@@ -38,6 +53,8 @@ class WhenChanged(pyinotify.ProcessEvent):
         self.paths = paths
         self.command = command
         self.recursive = recursive
+        self.suffixes = suffixes.split(',') if suffixes else []
+        self.last_run_time = datetime.now()
 
     def run_command(self, thefile):
         new_command = []
@@ -49,6 +66,8 @@ class WhenChanged(pyinotify.ProcessEvent):
 
     def is_interested(self, path):
         basename = os.path.basename(path)
+        suffix = path.split('.')[-1] if os.path.isfile(path) else None
+        is_allowed = suffix in self.suffixes
 
         if self.exclude.match(basename):
             return False
@@ -58,25 +77,27 @@ class WhenChanged(pyinotify.ProcessEvent):
 
         path = os.path.dirname(path)
         if path in self.paths:
-            return True
+            return True if is_allowed else False
 
         if self.recursive:
             while os.path.dirname(path) != path:
                 path = os.path.dirname(path)
                 if path in self.paths:
-                    return True
-
+                    return True if is_allowed else False
         return False
 
     def on_change(self, path):
         if self.is_interested(path):
             self.run_command(path)
 
+    @run_once
     def process_IN_CLOSE_WRITE(self, event):
         self.on_change(event.pathname)
 
+    @run_once
     def process_IN_MOVED_TO(self, event):
         self.on_change(event.pathname)
+        print('IN_MOVED_TO')
 
     def run(self):
         wm = pyinotify.WatchManager()
@@ -122,6 +143,17 @@ def main():
         recursive = True
         args.pop(0)
 
+    # Suffixes e.g. 'py,js,css' do not use space after comma
+    # Special usage: when-changed -r path/ -s py,js -c COMMAND
+    suffixes = None
+    if '-s' in args:
+        spos = args.index('-s')
+        suffixes = args[spos+1]
+        # Below order can not be changed
+        args.pop(spos+1)
+        args.pop(spos)
+    suffix_info = ' all [%s] files' % suffixes if suffixes else ''
+
     if '-c' in args:
         cpos = args.index('-c')
         files = args[:cpos]
@@ -137,16 +169,23 @@ def main():
     print_command = ' '.join(command)
 
     # Tell the user what we're doing
+    fileinfo = ''
     if len(files) > 1:
         l = ["'%s'" % f for f in files]
-        s = ', '.join(l[:-1]) + ' or ' + l[-1]
-        print("When %s changes, run '%s'" % (s, print_command))
+        fileinfo = ', '.join(l[:-1]) + ' or ' + l[-1]
+        fileinfo += suffix_info
     else:
-        print("When '%s' changes, run '%s'" % (files[0], print_command))
+        # one file or one directory
+        fileinfo = files[0] + suffix_info
+    print("When '%s' changes, run '%s'" % (fileinfo, print_command))
 
-    wc = WhenChanged(files, command, recursive)
+    wc = WhenChanged(files, command, recursive, suffixes)
     try:
         wc.run()
     except KeyboardInterrupt:
         print()
         exit(0)
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
1. Support `when-changed -r DIR -s py,js,css -c COMMAND `.
2. Filter some duplicately trigger event conditions.