### PR TITLE
Add -s flag to run the command immediately at start

### DIFF
--- a/whenchanged/whenchanged.py
+++ b/whenchanged/whenchanged.py
@@ -87,7 +87,7 @@ class WhenChanged(pyinotify.ProcessEvent):
 
     def run(self):
         if self.run_at_start:
-            self.run_command('')
+            self.run_command('/dev/null')
 
         wm = pyinotify.WatchManager()
         notifier = pyinotify.Notifier(wm, self)

--- a/whenchanged/whenchanged.py
+++ b/whenchanged/whenchanged.py
@@ -1,12 +1,13 @@
 #!/usr/bin/env python
 """%(prog)s - run a command when a file is changed
 
-Usage: %(prog)s [-v] [-r] [-1] FILE COMMAND...
-       %(prog)s [-v] [-r] [-1] FILE [FILE ...] -c COMMAND
+Usage: %(prog)s [-v] [-r] [-1] [-s] FILE COMMAND...
+       %(prog)s [-v] [-r] [-1] [-s] FILE [FILE ...] -c COMMAND
 
 FILE can be a directory. Watch recursively with -r.
 Verbose output with -v.
 -1 (run once) to not rerun if changes occured while the command was running.
+-s (run at start) to run the command immediately at start.
 Use %%f to pass the filename to the command.
 
 Copyright (c) 2011, Johannes H. Jensen.
@@ -124,6 +125,7 @@ def main():
     recursive = False
     verbose = False
     run_once = False
+    run_at_start = False
 
     while args and args[0][0] == '-':
         flag = args.pop(0)
@@ -133,6 +135,8 @@ def main():
             recursive = True
         elif flag == '-1':
             run_once = True
+        elif flag == '-s':
+            run_at_start = True
         elif flag == '-c':
             command = args
             args = []
@@ -164,6 +168,10 @@ def main():
             print("When '%s' changes, run '%s'" % (files[0], print_command))
 
     wc = WhenChanged(files, command, recursive, run_once)
+
+    if run_at_start:
+        wc.run_command('')
+
     try:
         wc.run()
     except KeyboardInterrupt:

--- a/whenchanged/whenchanged.py
+++ b/whenchanged/whenchanged.py
@@ -32,7 +32,7 @@ class WhenChanged(pyinotify.ProcessEvent):
     # Exclude Vim swap files, its file creation test file 4913 and backup files
     exclude = re.compile(r'^\..*\.sw[px]*$|^4913$|.~$')
 
-    def __init__(self, files, command, recursive=False, run_once=False):
+    def __init__(self, files, command, recursive=False, run_once=False, run_at_start=False):
         self.files = files
         paths = {}
         for f in files:
@@ -41,6 +41,7 @@ class WhenChanged(pyinotify.ProcessEvent):
         self.command = command
         self.recursive = recursive
         self.run_once = run_once
+        self.run_at_start = run_at_start
         self.last_run = 0
 
     def run_command(self, thefile):
@@ -85,6 +86,9 @@ class WhenChanged(pyinotify.ProcessEvent):
         self.on_change(event.pathname)
 
     def run(self):
+        if self.run_at_start:
+            self.run_command('')
+
         wm = pyinotify.WatchManager()
         notifier = pyinotify.Notifier(wm, self)
 
@@ -167,10 +171,7 @@ def main():
         if verbose:
             print("When '%s' changes, run '%s'" % (files[0], print_command))
 
-    wc = WhenChanged(files, command, recursive, run_once)
-
-    if run_at_start:
-        wc.run_command('')
+    wc = WhenChanged(files, command, recursive, run_once, run_at_start)
 
     try:
         wc.run()


### PR DESCRIPTION
When using `when-changed` for unit testing, I almost always want to run the command immediately. At the moment I usually switch back to my editor and re-save a file to trigger it. This adds a `-s` flag to run the command immediately at start.

(I would have used `-r` for "run", but that's already taken.)

Thanks!