### PR TITLE
changed setup.py from using 'scripts' to 'entry_point' 

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,8 @@ setup(name='when-changed',
       author_email='joh@pseudoberries.com',
       url='https://github.com/joh/when-changed',
       packages=['whenchanged'],
-      scripts=['when-changed'],
-      install_requires=['watchdog'],
+      entry_points={
+            'console_scripts': ('when-changed = whenchanged.whenchanged:main')
+      },      install_requires=['watchdog'],
       license='BSD'
       )


### PR DESCRIPTION
Doing `pip install when-changed` will now generate working `.exe` on windows. Installing still works on OSX/Linux for both Python 2/3.