### PR TITLE
Use get_opt instead of manual arguments parsing

### DIFF
--- a/run_unittests
+++ b/run_unittests
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+python -munittest discover

--- a/whenchanged/test_whenchanged.py
+++ b/whenchanged/test_whenchanged.py
@@ -25,6 +25,16 @@ class TestParseArgs(unittest.TestCase):
         self.assertEqual(list(wc.paths), ['/dev/null'])
         self.assertEqual(wc.command, ['echo', 'changed'])
 
+    def test_all_options_attached(self):
+        wc = whenchanged.parse_args('when-changed -sr1v /dev/null true'.split(' '))
+        self.assertIsNotNone(wc)
+
+        self.assertTrue(wc.recursive)
+        self.assertTrue(wc.run_once)
+        self.assertTrue(wc.run_at_start)
+        self.assertEqual(list(wc.paths), ['/dev/null'])
+        self.assertEqual(wc.command, ['true'])
+
     def test_all_options(self):
         wc = whenchanged.parse_args('when-changed -s -r -1 -v /dev/null true'.split(' '))
         self.assertIsNotNone(wc)
@@ -42,6 +52,20 @@ class TestParseArgs(unittest.TestCase):
         self.assertEqual(list(wc.paths), ['/dev/null', '/dev'])
         self.assertEqual(wc.command, ['echo', 'changed'])
 
+    def test_command_c_and_options(self):
+        wc = whenchanged.parse_args('when-changed -r /dev/null /dev -c echo changed'.split(' '))
+        self.assertIsNotNone(wc)
+
+        self.assertTrue(wc.recursive)
+        self.assertEqual(list(wc.paths), ['/dev/null', '/dev'])
+        self.assertEqual(wc.command, ['echo', 'changed'])
+
+    def test_command_cattached(self):
+        wc = whenchanged.parse_args('when-changed /dev/null /dev -ctrue'.split(' '))
+        self.assertIsNotNone(wc)
+
+        self.assertEqual(list(wc.paths), ['/dev/null', '/dev'])
+        self.assertEqual(wc.command, ['true'])
 
 if __name__ == "__main__":
     unittest.main()

--- a/whenchanged/test_whenchanged.py
+++ b/whenchanged/test_whenchanged.py
@@ -1,0 +1,10 @@
+#! /usr/bin/env python
+
+import unittest
+from whenchanged import *
+
+class TestWhenChanged(unittest.TestCase):
+    pass
+
+if __name__ == "__main__":
+    unittest.main()

--- a/whenchanged/test_whenchanged.py
+++ b/whenchanged/test_whenchanged.py
@@ -75,5 +75,17 @@ class TestParseArgs(unittest.TestCase):
         self.assertSimilar(list(wc.paths), ['/dev/null', '/dev'])
         self.assertEqual(wc.command, ['true'])
 
+    def test_command_c_with_options(self):
+        wc = self.construct_WhenChanged('when-changed /dev/null -v /dev -sccat -s %f')
+
+        self.assertSimilar(list(wc.paths), ['/dev/null', '/dev'])
+        self.assertEqual(wc.command, ['cat', '-s', '%f'])
+
+    def test_command_c_with_options_2(self):
+        wc = self.construct_WhenChanged('when-changed /dev/null -c echo -Z')
+
+        self.assertSimilar(list(wc.paths), ['/dev/null'])
+        self.assertEqual(wc.command, ['echo', '-Z'])
+
 if __name__ == "__main__":
     unittest.main()

--- a/whenchanged/test_whenchanged.py
+++ b/whenchanged/test_whenchanged.py
@@ -1,9 +1,15 @@
 #! /usr/bin/env python
 
 import unittest
-from whenchanged import whenchanged
+try:
+    from whenchanged import whenchanged
+except:
+    import whenchanged
 
 class TestParseArgs(unittest.TestCase):
+    def assertSimilar(self, l1, l2):
+        return self.assertEqual(sorted(l1), sorted(l2))
+
     def test_simple(self):
         wc = whenchanged.parse_args('when-changed /dev/null true'.split(' '))
         self.assertIsNotNone(wc)
@@ -49,7 +55,7 @@ class TestParseArgs(unittest.TestCase):
         wc = whenchanged.parse_args('when-changed /dev/null /dev -c echo changed'.split(' '))
         self.assertIsNotNone(wc)
 
-        self.assertEqual(list(wc.paths), ['/dev/null', '/dev'])
+        self.assertSimilar(list(wc.paths), ['/dev/null', '/dev'])
         self.assertEqual(wc.command, ['echo', 'changed'])
 
     def test_command_c_followed_by_other(self):
@@ -57,7 +63,7 @@ class TestParseArgs(unittest.TestCase):
         self.assertIsNotNone(wc)
 
         self.assertFalse(wc.recursive)
-        self.assertEqual(list(wc.paths), ['/dev/null', '/dev'])
+        self.assertSimilar(list(wc.paths), ['/dev/null', '/dev'])
         self.assertEqual(wc.command, ['ls', '-r'])
 
     def test_command_c_and_options(self):
@@ -65,14 +71,14 @@ class TestParseArgs(unittest.TestCase):
         self.assertIsNotNone(wc)
 
         self.assertTrue(wc.recursive)
-        self.assertEqual(list(wc.paths), ['/dev/null', '/dev'])
+        self.assertSimilar(list(wc.paths), ['/dev/null', '/dev'])
         self.assertEqual(wc.command, ['echo', 'changed'])
 
     def test_command_cattached(self):
         wc = whenchanged.parse_args('when-changed /dev/null /dev -ctrue'.split(' '))
         self.assertIsNotNone(wc)
 
-        self.assertEqual(list(wc.paths), ['/dev/null', '/dev'])
+        self.assertSimilar(list(wc.paths), ['/dev/null', '/dev'])
         self.assertEqual(wc.command, ['true'])
 
 if __name__ == "__main__":

--- a/whenchanged/test_whenchanged.py
+++ b/whenchanged/test_whenchanged.py
@@ -52,6 +52,14 @@ class TestParseArgs(unittest.TestCase):
         self.assertEqual(list(wc.paths), ['/dev/null', '/dev'])
         self.assertEqual(wc.command, ['echo', 'changed'])
 
+    def test_command_c_followed_by_other(self):
+        wc = whenchanged.parse_args('when-changed /dev/null /dev -c ls -r'.split(' '))
+        self.assertIsNotNone(wc)
+
+        self.assertFalse(wc.recursive)
+        self.assertEqual(list(wc.paths), ['/dev/null', '/dev'])
+        self.assertEqual(wc.command, ['ls', '-r'])
+
     def test_command_c_and_options(self):
         wc = whenchanged.parse_args('when-changed -r /dev/null /dev -c echo changed'.split(' '))
         self.assertIsNotNone(wc)

--- a/whenchanged/test_whenchanged.py
+++ b/whenchanged/test_whenchanged.py
@@ -10,9 +10,11 @@ class TestParseArgs(unittest.TestCase):
     def assertSimilar(self, l1, l2):
         return self.assertEqual(sorted(l1), sorted(l2))
 
+    def construct_WhenChanged(self, cmd):
+        return whenchanged.WhenChanged(**whenchanged.parse_args(cmd.split(' ')))
+
     def test_simple(self):
-        wc = whenchanged.parse_args('when-changed /dev/null true'.split(' '))
-        self.assertIsNotNone(wc)
+        wc = self.construct_WhenChanged('when-changed /dev/null true')
 
         self.assertFalse(wc.recursive)
         self.assertFalse(wc.run_once)
@@ -21,19 +23,16 @@ class TestParseArgs(unittest.TestCase):
         self.assertEqual(wc.command, ['true'])
 
     def test_help(self):
-        wc = whenchanged.parse_args('when-changed -h'.split(' '))
-        self.assertIsNone(wc)
+        self.assertIsNone(whenchanged.parse_args('when-changed -h'.split(' ')))
 
     def test_long_command(self):
-        wc = whenchanged.parse_args('when-changed /dev/null echo changed'.split(' '))
-        self.assertIsNotNone(wc)
+        wc = self.construct_WhenChanged('when-changed /dev/null echo changed')
 
         self.assertEqual(list(wc.paths), ['/dev/null'])
         self.assertEqual(wc.command, ['echo', 'changed'])
 
     def test_all_options_attached(self):
-        wc = whenchanged.parse_args('when-changed -sr1v /dev/null true'.split(' '))
-        self.assertIsNotNone(wc)
+        wc = self.construct_WhenChanged('when-changed -sr1v /dev/null true')
 
         self.assertTrue(wc.recursive)
         self.assertTrue(wc.run_once)
@@ -42,8 +41,7 @@ class TestParseArgs(unittest.TestCase):
         self.assertEqual(wc.command, ['true'])
 
     def test_all_options(self):
-        wc = whenchanged.parse_args('when-changed -s -r -1 -v /dev/null true'.split(' '))
-        self.assertIsNotNone(wc)
+        wc = self.construct_WhenChanged('when-changed -s -r -1 -v /dev/null true')
 
         self.assertTrue(wc.recursive)
         self.assertTrue(wc.run_once)
@@ -52,31 +50,27 @@ class TestParseArgs(unittest.TestCase):
         self.assertEqual(wc.command, ['true'])
 
     def test_command_c(self):
-        wc = whenchanged.parse_args('when-changed /dev/null /dev -c echo changed'.split(' '))
-        self.assertIsNotNone(wc)
+        wc = self.construct_WhenChanged('when-changed /dev/null /dev -c echo changed')
 
         self.assertSimilar(list(wc.paths), ['/dev/null', '/dev'])
         self.assertEqual(wc.command, ['echo', 'changed'])
 
     def test_command_c_followed_by_other(self):
-        wc = whenchanged.parse_args('when-changed /dev/null /dev -c ls -r'.split(' '))
-        self.assertIsNotNone(wc)
+        wc = self.construct_WhenChanged('when-changed /dev/null /dev -c ls -r')
 
         self.assertFalse(wc.recursive)
         self.assertSimilar(list(wc.paths), ['/dev/null', '/dev'])
         self.assertEqual(wc.command, ['ls', '-r'])
 
     def test_command_c_and_options(self):
-        wc = whenchanged.parse_args('when-changed -r /dev/null /dev -c echo changed'.split(' '))
-        self.assertIsNotNone(wc)
+        wc = self.construct_WhenChanged('when-changed -r /dev/null /dev -c echo changed')
 
         self.assertTrue(wc.recursive)
         self.assertSimilar(list(wc.paths), ['/dev/null', '/dev'])
         self.assertEqual(wc.command, ['echo', 'changed'])
 
     def test_command_cattached(self):
-        wc = whenchanged.parse_args('when-changed /dev/null /dev -ctrue'.split(' '))
-        self.assertIsNotNone(wc)
+        wc = self.construct_WhenChanged('when-changed /dev/null /dev -ctrue')
 
         self.assertSimilar(list(wc.paths), ['/dev/null', '/dev'])
         self.assertEqual(wc.command, ['true'])

--- a/whenchanged/test_whenchanged.py
+++ b/whenchanged/test_whenchanged.py
@@ -1,10 +1,47 @@
 #! /usr/bin/env python
 
 import unittest
-from whenchanged import *
+from whenchanged import whenchanged
 
-class TestWhenChanged(unittest.TestCase):
-    pass
+class TestParseArgs(unittest.TestCase):
+    def test_simple(self):
+        wc = whenchanged.parse_args('when-changed /dev/null true'.split(' '))
+        self.assertIsNotNone(wc)
+
+        self.assertFalse(wc.recursive)
+        self.assertFalse(wc.run_once)
+        self.assertFalse(wc.run_at_start)
+        self.assertEqual(list(wc.paths), ['/dev/null'])
+        self.assertEqual(wc.command, ['true'])
+
+    def test_help(self):
+        wc = whenchanged.parse_args('when-changed -h'.split(' '))
+        self.assertIsNone(wc)
+
+    def test_long_command(self):
+        wc = whenchanged.parse_args('when-changed /dev/null echo changed'.split(' '))
+        self.assertIsNotNone(wc)
+
+        self.assertEqual(list(wc.paths), ['/dev/null'])
+        self.assertEqual(wc.command, ['echo', 'changed'])
+
+    def test_all_options(self):
+        wc = whenchanged.parse_args('when-changed -s -r -1 -v /dev/null true'.split(' '))
+        self.assertIsNotNone(wc)
+
+        self.assertTrue(wc.recursive)
+        self.assertTrue(wc.run_once)
+        self.assertTrue(wc.run_at_start)
+        self.assertEqual(list(wc.paths), ['/dev/null'])
+        self.assertEqual(wc.command, ['true'])
+
+    def test_command_c(self):
+        wc = whenchanged.parse_args('when-changed /dev/null /dev -c echo changed'.split(' '))
+        self.assertIsNotNone(wc)
+
+        self.assertEqual(list(wc.paths), ['/dev/null', '/dev'])
+        self.assertEqual(wc.command, ['echo', 'changed'])
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/whenchanged/whenchanged.py
+++ b/whenchanged/whenchanged.py
@@ -139,10 +139,9 @@ def print_usage(prog):
 
 def parse_args(argv):
     """
-    Parse the various args and returns a WhenChanged object.
+    Parse the various args and returns a dictionnary.
 
-    The function can return None if the arguments were correct but
-    could not build an object (eg display help).
+    The function returns None if the arguments were asking for the help.
 
     The function raises ValueError in case of bad arguments.
     """

--- a/whenchanged/whenchanged.py
+++ b/whenchanged/whenchanged.py
@@ -2,8 +2,7 @@
 """%(prog)s - run a command when a file is changed
 
 Usage: %(prog)s [-vr1s] FILE COMMAND...
-       %(prog)s [-vr1s] FILE [FILE ...] -c COMMAND
-       %(prog)s --help
+       %(prog)s [-vr1s] FILE [FILE ...] -c COMMAND...
 
 FILE can be a directory. Use %%f to pass the filename to the command.
 
@@ -181,7 +180,7 @@ def parse_args(argv):
                 command += [remain]
             if a_i < len(argv):
                 command += argv[a_i + 1:]
-            
+
             # shiftargs ignores any option before -c and any argument after -c
             shiftargs = [a for a in argv[0:a_i] if not re.match(r'\-', a) ]
             break

--- a/whenchanged/whenchanged.py
+++ b/whenchanged/whenchanged.py
@@ -135,14 +135,20 @@ class WhenChanged(FileSystemEventHandler):
 def print_usage(prog):
     print(__doc__ % {'prog': prog}, end='')
 
+def parse_args(args):
+    """
+    Parse the various args and returns a WhenChanged object.
 
-def main():
-    args = sys.argv
+    The function can return None if the arguments were correct but
+    could not build an object (eg display help).
+
+    The function raises ValueError in case of bad arguments.
+    """
     prog = os.path.basename(args.pop(0))
 
     if '-h' in args or '--help' in args:
         print_usage(prog)
-        exit(0)
+        return None
 
     files = []
     command = []
@@ -176,8 +182,7 @@ def main():
         command = args[1:]
 
     if not files or not command:
-        print_usage(prog)
-        exit(1)
+        raise ValueError()
 
     print_command = ' '.join(command)
 
@@ -191,7 +196,17 @@ def main():
         if verbose:
             print("When '%s' changes, run '%s'" % (files[0], print_command))
 
-    wc = WhenChanged(files, command, recursive, run_once, run_at_start)
+    return WhenChanged(files, command, recursive, run_once, run_at_start)
+
+def main():
+    try:
+        wc = parse_args(sys.argv)
+    except ValueError:
+        print_usage(prog)
+        exit(1)
+
+    if wc is None:
+        exit(0)
 
     try:
         wc.run()

--- a/whenchanged/whenchanged.py
+++ b/whenchanged/whenchanged.py
@@ -169,8 +169,22 @@ def parse_args(argv):
         elif arg == '-s':
             run_at_start = True
         elif arg == '-c':
-            command = [argopt]
-            args = []
+            # special case: all following arguments are part of a command
+            r_c = re.compile(r'\-[^\-]*c(.*)')
+            a = [a for a in argv if r_c.match(a)][0]
+            a_i = argv.index(a)
+
+            # two things to take as argument to -c: directly attached and following: -carg1 arg2
+            remain = r_c.match(a).groups()[0]
+            command = []
+            if remain != '':
+                command += [remain]
+            if a_i < len(argv):
+                command += argv[a_i + 1:]
+            
+            # shiftargs ignores any option before -c and any argument after -c
+            shiftargs = [a for a in argv[0:a_i] if not re.match(r'\-', a) ]
+            break
         else:
             break
 

--- a/whenchanged/whenchanged.py
+++ b/whenchanged/whenchanged.py
@@ -208,11 +208,12 @@ def parse_args(argv):
         if verbose:
             print("When '%s' changes, run '%s'" % (files[0], print_command))
 
-    return WhenChanged(files, command, recursive, run_once, run_at_start)
+    return {"files":files, "command":command, "recursive":recursive, "run_once":run_once, "run_at_start":run_at_start}
 
 def main():
     try:
-        wc = parse_args(sys.argv)
+        kw = parse_args(sys.argv)
+        wc = WhenChanged(**kw)
     except ValueError:
         print_usage(prog)
         exit(2)


### PR DESCRIPTION
The argument parsing method of when-changed is lacking: you cannot freely reorder the "-c" argument and you cannot join options together; for example if you want the command foo to run immediately on the current directory, with verbosity on, recursively, you must call

`# when-changed -r -v -1 . foo`

with these changes you can now also call

`# when-changed -rv1 . foo`

These changes also make possible reordering the -c option; eg:

`# when-changed -rc foo .`

Finally I attached two minor changes as well: added -h and --help to usage and fixed the exit status in case of command misuse (bad argument): it is commonly set to 2 in order to differentiate it from more general errors (it is not per any standard so this can be reverted).