### PR TITLE
fix keyError in verbose mode

### DIFF
--- a/whenchanged/whenchanged.py
+++ b/whenchanged/whenchanged.py
@@ -84,7 +84,7 @@ class WhenChanged(FileSystemEventHandler):
         now = datetime.now()
         print_message = ''
         if self.verbose_mode > 0:
-            print_message = "'" + self.paths[thefile] + "' changed"
+            print_message = "'" + thefile + "' changed"
         if self.verbose_mode > 1:
             print_message += ' at ' + now.strftime('%F %T')
         if self.verbose_mode > 2:


### PR DESCRIPTION
A keyError is thrown when recursively watching in a folder in verbose mode.
The 'thefile' parameter passed to the run_command method represents the file that has been modified whereas self.paths contains only its folder.

Signed-off-by: Eric Villard <dev@eviweb.fr>