### PR TITLE
fix issue #73: support for environment variables

### DIFF
--- a/whenchanged/whenchanged.py
+++ b/whenchanged/whenchanged.py
@@ -92,7 +92,7 @@ class WhenChanged(FileSystemEventHandler):
             print_message += '.' + now.strftime('%f') + ", running '" + ' '.join(self.command) + "'"
         if print_message:
             print('==> ' + print_message + ' <==')
-        subprocess.Popen(new_command, shell=(len(new_command) == 1), env=self.process_env)
+        subprocess.call(new_command, shell=(len(new_command) == 1), env=self.process_env)
         self.last_run = time.time()
 
     def is_interested(self, path):

--- a/whenchanged/whenchanged.py
+++ b/whenchanged/whenchanged.py
@@ -61,6 +61,7 @@ class WhenChanged(FileSystemEventHandler):
         self.run_at_start = run_at_start
         self.last_run = 0
         self.verbose_mode = verbose_mode
+        self.process_env = os.environ.copy()
 
         self.observer = Observer(timeout=0.1)
 
@@ -91,7 +92,7 @@ class WhenChanged(FileSystemEventHandler):
             print_message += '.' + now.strftime('%f') + ", running '" + ' '.join(self.command) + "'"
         if print_message:
             print('==> ' + print_message + ' <==')
-        subprocess.call(new_command, shell=(len(new_command) == 1))
+        subprocess.Popen(new_command, shell=(len(new_command) == 1), env=self.process_env)
         self.last_run = time.time()
 
     def is_interested(self, path):
@@ -132,6 +133,9 @@ class WhenChanged(FileSystemEventHandler):
     def on_moved(self, event):
         if not event.is_directory:
             self.on_change(event.dest_path)
+
+    def set_envvar(self, name, value):
+        self.process_env['WHEN_CHANGED_' + name.upper()] = value
 
     def run(self):
         if self.run_at_start:


### PR DESCRIPTION
It provides a new dict attribute `process_env` and a setter method called `set_envvar`.
The latter accepts two arguments: `name` and `value`
The name does not need to be passed in uppercase, and will automatically be prefixed with `WHEN_CHANGED_` to prevent conflicts.
eg. self.set_envvar('myvar', 'myvalue') will result in an environment variable `WHEN_CHANGED_MYVAR` = `myvalue`.

Only the sub process is altered as suggested here https://github.com/joh/when-changed/pull/72#pullrequestreview-217539245
and shown here https://stackoverflow.com/questions/2231227/python-subprocess-popen-with-a-modified-environment

Signed-off-by: Eric Villard <dev@eviweb.fr>