### PR TITLE
Fix issues #68 and #76

### DIFF
--- a/whenchanged/whenchanged.py
+++ b/whenchanged/whenchanged.py
@@ -136,7 +136,7 @@ class WhenChanged(FileSystemEventHandler):
     def on_modified(self, event):
         if not event.is_directory and self.last_event_type != 'created':
             self.on_change(event.src_path, event)
-        elif not event.is_directory:
+        if not event.is_directory and self.last_event_type == 'created':
             self.last_event_type = event.event_type
 
     def on_moved(self, event):

--- a/whenchanged/whenchanged.py
+++ b/whenchanged/whenchanged.py
@@ -125,29 +125,26 @@ class WhenChanged(FileSystemEventHandler):
     def on_change(self, path, event = None):
         if event is not None and not event.is_directory:
             self.last_event_type = event.event_type
+            self.set_envvar('event', 'file_' + event.event_type)
         if self.is_interested(path):
             self.run_command(path)
 
     def on_created(self, event):
         if not event.is_directory:
-            self.set_envvar('event', 'file_created')
             self.on_change(event.src_path, event)
 
     def on_modified(self, event):
         if not event.is_directory and self.last_event_type != 'created':
-            self.set_envvar('event', 'file_modified')
             self.on_change(event.src_path, event)
         elif not event.is_directory:
             self.last_event_type = event.event_type
 
     def on_moved(self, event):
         if not event.is_directory:
-            self.set_envvar('event', 'file_moved')
             self.on_change(event.src_path, event)
 
     def on_deleted(self, event):
         if not event.is_directory:
-            self.set_envvar('event', 'file_deleted')
             self.on_change(event.src_path, event)
 
     def set_envvar(self, name, value):

--- a/whenchanged/whenchanged.py
+++ b/whenchanged/whenchanged.py
@@ -141,7 +141,7 @@ class WhenChanged(FileSystemEventHandler):
 
     def on_moved(self, event):
         if not event.is_directory:
-            self.on_change(event.src_path, event)
+            self.on_change(event.dest_path, event)
 
     def on_deleted(self, event):
         if not event.is_directory:


### PR DESCRIPTION
Keep track of the last event to prevent a created event to be followed by a modified event.

Take care of the `on_change` method signature that now takes an optional `event` argument.
This is a backward compatible change as the argument is optional and has a default value.
I made this choice to propose a better code design and a better readability.

best regards