### PR TITLE
Fix issue #31: Hide any output of given command/s

### DIFF
--- a/README
+++ b/README
@@ -43,6 +43,7 @@
          The maximum is 3: -vvv.
       -1 Don't re-run command if files changed while command was running
       -s Run command immediately at start
+      -q Run command quietly
 
     ~ Environment variables
 


### PR DESCRIPTION
`when-changed` now provides a `-q` option to enable a silent mode.

Signed-off-by: Eric Villard <dev@eviweb.fr>