### PR TITLE
Set event variable on start and ad support for a kill flag

### DIFF
--- a/whenchanged/whenchanged.py
+++ b/whenchanged/whenchanged.py
@@ -178,6 +178,7 @@ class WhenChanged(FileSystemEventHandler):
 
     def run(self):
         if self.run_at_start:
+            self.set_envvar('event', 'start')
             self.run_command('/dev/null')
 
         self.observer.start()


### PR DESCRIPTION
The env variable event was previously unset in the case of the first run. This isn't impossible to handle in scripts using $event but it is more convenient to provide a consistent value.