### PR TITLE
Recommend `pipx` to install, instead of `pip`

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Sweetness!
 
 ### Installation
 ```sh
-pip install https://github.com/joh/when-changed/archive/master.zip
+pipx install https://github.com/joh/when-changed/archive/master.zip
 ```
 
 


### PR DESCRIPTION
At least on Ubuntu 24.04, `pip` would error out with `error: externally-managed-environment`. According to the following SO, the proper way for an application that should be globally available, is to use `pipx` instead.

See https://stackoverflow.com/a/78652149/37706